### PR TITLE
use `URL` class

### DIFF
--- a/send.js
+++ b/send.js
@@ -40,7 +40,9 @@
     }
     //String replacement process for URLs
     let urlReplace = (url) =>  {
-        return url.replace(/&list.*/, '');
+        const u = new URL(url);
+        u.searchParams.delete('list');
+        return u.toString();
     }
 
     chrome.contextMenus.create({


### PR DESCRIPTION
Rewrite `URLSearchParams.delete()` to remove parameters.

<https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/delete>